### PR TITLE
Allow mixed-case (camelCase) variable and class names

### DIFF
--- a/puppet.jsf
+++ b/puppet.jsf
@@ -93,11 +93,11 @@
 
 :variable Var
 	*		idle		noeat
-	"a-z0-9_"	variable
+	"a-zA-Z0-9_"	variable
 
 :type Type
 	*		idle		noeat
-	"a-z0-9_"	type
+	"a-zA-Z0-9_"	type
 
 :ident Idle
 	*		idle		noeat strings


### PR DESCRIPTION
Some modules have camelCase variable names, but the syntax highlighting would give the "camel" and the "Case" a different color. This fixes that.
