### PR TITLE
Improve Perl detection

### DIFF
--- a/ftyperc
+++ b/ftyperc
@@ -199,7 +199,7 @@
 
  Perl
 *
-+#!\+\[ 	]\+\[a-z/]/perl\>
++#!\+\[ 	]\+\[a-z/]\[/ ]perl\>
 -autoindent
 -syntax perl
 -smarthome
@@ -216,6 +216,14 @@
 -single_quoted
 
 *.pm
+-autoindent
+-syntax perl
+-smarthome
+-smartbacks
+-pound_comment
+-single_quoted
+
+*.t
 -autoindent
 -syntax perl
 -smarthome


### PR DESCRIPTION
Specifically, this allows for detection of `#!/usr/bin/env perl` which is increasingly common. It also adds the standard Perl test extension .t 
