### PR TITLE
Rewrite JavaScript syntax highlighting

### DIFF
--- a/js.jsf
+++ b/js.jsf
@@ -41,7 +41,7 @@
 
 :idle Idle
 	*			idle
-	"/"			regex_or_comment	recolor=-1
+	"/"			re_or_comment	recolor=-1
 	"0"			first_digit	recolor=-1
 	"1-9"			decimal		recolor=-1
 	"."			maybe_float
@@ -171,7 +171,7 @@ done
 	"\"'"			after_term
 	"a-zA-Z0-9_."		bad_after_term
 
-:regex_or_comment Syntax
+:re_or_comment Syntax
 	*			regex		recolor=-2
 	"*/"			maybe_comment	noeat
 
@@ -324,7 +324,7 @@ done
 	"a-zA-Z0-9_"		infix_operator
 
 :bad_op Bad
-	*			idle	noeat
+	*			idle		noeat
 	"a-zA-Z0-9_"		bad_op
 
 :operator Operator
@@ -479,7 +479,7 @@ done
 	"a-zA-Z0-9_"		export_item
 
 :lit Constant
-	*			lit_end	noeat
+	*			lit_end		noeat
 
 :lit_end Constant
 	*			after_term	noeat
@@ -490,24 +490,24 @@ done
 
 .subr comment_todo
 # initial state
-:comment_todo_init Comment
-	*			comment_todo_guess	buffer
+:todo_init Comment
+	*			todo_guess	buffer
 
 # highlight common TODO labels
-:comment_todo_guess Comment
-	*			comment_todo_unknown	noeat strings
-	"BUG"			comment_todo
-	"FIXME"			comment_todo
-	"HACK"			comment_todo
-	"NOTE"			comment_todo
-	"TODO"			comment_todo
-	"XXX"			comment_todo
+:todo_guess Comment
+	*			todo_unknown	noeat strings
+	"BUG"			todo
+	"FIXME"			todo
+	"HACK"			todo
+	"NOTE"			todo
+	"TODO"			todo
+	"XXX"			todo
 done
-	"A-Z"			comment_todo_guess
+	"A-Z"			todo_guess
 
-:comment_todo_unknown Comment
-	*			NULL			noeat return
+:todo_unknown Comment
+	*			NULL		noeat return
 
-:comment_todo CommentLabel
-	*			NULL			noeat return
+:todo CommentLabel
+	*			NULL		noeat return
 .end


### PR DESCRIPTION
- Fixes bug that made division get marked up as regexp
- Highlights assignment to differentiate it from equality checks
- Adds a bunch of new highlighting categories (no color changes by default however)
- More syntax errors will be marked as bad (multi-line strings, multiple identifiers in a row, etc)
- Single and double quotes correctly treated the same
- Ident's can include $
