### PR TITLE
Fix Python decorators highlighting

### DIFF
--- a/python.jsf
+++ b/python.jsf
@@ -35,7 +35,8 @@
 # annotations
 :decorator Decorator
 	*		decorator
-	" \t\r\n"	idle		noeat
+	"\"'"		string_sq	recolor=-1
+	"(\t\r\n"	idle		noeat
 
 :comment Comment
 	*		comment


### PR DESCRIPTION
This fixes highlighting of the decorators with arguments. For example, the following code highlighting was broken:

``` python

@first
@second("arg1", "arg2")
def my_fun():
    pass

```
