### PR TITLE
Fix close bracket after function arity

### DIFF
--- a/erlang.jsf
+++ b/erlang.jsf
@@ -232,7 +232,7 @@ done
 
 :funarity Fun
 	*		function	recolormark noeat
-	"0-9"		funtroll
+	"0-9"		idle
 
 :kw Keyword
 	*		idle		noeat


### PR DESCRIPTION
This small fix repairs close square bracket highlighting in Erlang export statement. Code example, that demonstrates the issue is below:

```erlang
-module(hello).
-export([hello/0]).

hello() ->
        io:format("Hello, World~n").
```

Without the fix square bracket after ``hello/0`` will not be highlighted properly.