### PR TITLE
yaml.jsf: handle plain strings w/ non-initial quotes

### DIFF
--- a/yaml.jsf
+++ b/yaml.jsf
@@ -20,20 +20,12 @@
 :line_start Idle
 	*		maybe_key	noeat
 	"\t"		bad_tab		recolor=-1
-	"#"		maybe_lscomment1
+	"#"		line_comment	recolor=-1
 	" "		line_start
-
-:maybe_lscomment1 Idle
-	*		maybe_key	noeat
-	" "		line_comment	recolor=-2
 
 :maybe_idlecomment Comment
 	*		idle		noeat
-	"#"		maybe_idlecomment2
-
-:maybe_idlecomment2 Comment
-	*		idle		recolor=-2
-	" "		line_comment	recolor=-2
+	"#"		line_comment	recolor=-1
 
 :idle Constant
 	*		idle

--- a/yaml.jsf
+++ b/yaml.jsf
@@ -28,7 +28,7 @@
 	"#"		line_comment	recolor=-1
 
 :idle Constant
-	*		idle
+	*		plain_scalar	noeat
 	"\n"		line_start
 	" "		maybe_idlecomment
 	"%"		directive	recolor=-1
@@ -38,6 +38,11 @@
 	"."		maybe_block_end1
 	"*&"		maybe_reference
 	"!"		maybe_typecast
+
+:plain_scalar Constant
+	*		plain_scalar
+	"\t"		bad_tab		recolor=-1
+	"\n"		line_start      noeat
 
 :maybe_key Idle
 	*		maybe_key1	recolor=-1 mark

--- a/yaml.jsf
+++ b/yaml.jsf
@@ -1,4 +1,5 @@
 # JOE syntax highlight file for YAML
+# by Christian Nicolai (http://mycrobase.de)
 
 =Idle
 =Comment	green
@@ -11,7 +12,7 @@
 
 =Directive	red
 =Reference	yellow
-=LocalType	fg_310 # brown
+=LocalType	blue
 =BlockDelim	bold blue
 
 =BadTab		inverse red
@@ -19,13 +20,26 @@
 :line_start Idle
 	*		maybe_key	noeat
 	"\t"		bad_tab		recolor=-1
+	"#"		maybe_lscomment1
 	" "		line_start
+
+:maybe_lscomment1 Idle
+	*		maybe_key	noeat
+	" "		line_comment	recolor=-2
+
+:maybe_idlecomment Comment
+	*		idle		noeat
+	"#"		maybe_idlecomment2
+
+:maybe_idlecomment2 Comment
+	*		idle		recolor=-2
+	" "		line_comment	recolor=-2
 
 :idle Constant
 	*		idle
 	"\n"		line_start
+	" "		maybe_idlecomment
 	"%"		directive	recolor=-1
-	"#"		line_comment	recolor=-1
 	"'"		string_sq_1	recolor=-1
 	"\""		string_dq_1	recolor=-1
 	"{[]}"		brace		recolor=-1
@@ -35,7 +49,8 @@
 
 :maybe_key Idle
 	*		maybe_key1	recolor=-1 mark
-	"\n%#'\"{[]}*&!"	idle		noeat
+	"\n"		line_start
+	"%#'\"{[]}*&!"	idle		noeat
 	"-"		maybe_block1	mark
 
 :maybe_key1 Constant


### PR DESCRIPTION
This minor change allows yaml.jsf to better handle plain (i.e. unquoted literal) strings with embedded single or double quotes. The following 4-line yaml illustrates the problem.
```yaml
---
string1: This string doesn't continue on the next line.
string2: This string doesn't start on the previous line.
string3: This string is self-contained too.
```
The github syntaxer gets it right, but yaml.jsf highlights the "string2:" part as if it's a continuation of the prior line's string.  Actually, part of a single-quoted string that starts in the 1st "doesn't" and ends in the 2nd. This patch fixes that.