### PR TITLE
yaml: handle plain strings w/ non-initial quotes

### DIFF
--- a/yaml.jsf
+++ b/yaml.jsf
@@ -23,11 +23,15 @@
 	"#"		line_comment	recolor=-1
 	" "		line_start
 
+:maybe_idlecomment Comment
+	*		idle		noeat
+	"#"		line_comment	recolor=-1
+
 :idle Constant
-	*		idle
+	*		plain_scalar	noeat
 	"\n"		line_start
+	" "		maybe_idlecomment
 	"%"		directive	recolor=-1
-	" "		maybe_line_comment
 	"'"		string_sq_1	recolor=-1
 	"\""		string_dq_1	recolor=-1
 	"{[]}"		brace		recolor=-1
@@ -35,9 +39,15 @@
 	"*&"		maybe_reference
 	"!"		maybe_typecast
 
+:plain_scalar Constant
+	*		plain_scalar
+	"\t"		bad_tab		recolor=-1
+	"\n"		line_start	noeat
+
 :maybe_key Idle
 	*		maybe_key1	recolor=-1 mark
-	"\n%#'\"{[]}*&!"	idle		noeat
+	"\n"		line_start
+	"%#'\"{[]}*&!"	idle		noeat
 	"-"		maybe_block1	mark
 
 :maybe_key1 Constant
@@ -55,10 +65,6 @@
 # mark bad tabs until the first non-whitespace
 :bad_tab BadTab
 	*		line_start	noeat
-
-:maybe_line_comment Comment
-	*		idle		noeat
-	"#"		line_comment
 
 :line_comment Comment
 	*		line_comment

--- a/yaml.jsf
+++ b/yaml.jsf
@@ -23,15 +23,11 @@
 	"#"		line_comment	recolor=-1
 	" "		line_start
 
-:maybe_idlecomment Comment
-	*		idle		noeat
-	"#"		line_comment	recolor=-1
-
 :idle Constant
 	*		plain_scalar	noeat
 	"\n"		line_start
-	" "		maybe_idlecomment
 	"%"		directive	recolor=-1
+	" "		maybe_idle_comment
 	"'"		string_sq_1	recolor=-1
 	"\""		string_dq_1	recolor=-1
 	"{[]}"		brace		recolor=-1
@@ -43,6 +39,7 @@
 	*		plain_scalar
 	"\t"		bad_tab		recolor=-1
 	"\n"		line_start	noeat
+	" "		maybe_plain_scalar_comment
 
 :maybe_key Idle
 	*		maybe_key1	recolor=-1 mark
@@ -65,6 +62,14 @@
 # mark bad tabs until the first non-whitespace
 :bad_tab BadTab
 	*		line_start	noeat
+
+:maybe_plain_scalar_comment Comment
+	*		plain_scalar	noeat
+	"#"		line_comment
+
+:maybe_idle_comment Comment
+	*		idle		noeat
+	"#"		line_comment
 
 :line_comment Comment
 	*		line_comment


### PR DESCRIPTION
This minor change allows yaml.jsf to better handle plain (i.e. unquoted literal) strings with embedded single or double quotes. The following 4-line yaml illustrates the problem.
```yaml
---
string1: This string doesn't continue on the next line.
string2: This string doesn't start on the previous line.
string3: This string is self-contained too.
```
The github syntaxer gets it right, but yaml.jsf highlights the "string2:" part as if it's a continuation of the prior line's string. Actually, part of a single-quoted string that starts in the 1st "doesn't" and ends in the 2nd "doesn't". This patch fixes that.