### PR TITLE
tweak comment detection

### DIFF
--- a/yaml.jsf
+++ b/yaml.jsf
@@ -34,6 +34,7 @@
 	"."		maybe_block_end1
 	"*&"		maybe_reference
 	"!"		maybe_typecast
+	"#"		line_comment	recolor=-1
 
 :plain_scalar Constant
 	*		plain_scalar


### PR DESCRIPTION
I have a bunch of ansible YAML with to-end-of-line documentation, and it wasn't, you know, green.  This makes it happen.

Example of line:
    - ruby-ldap # for name script