### PR TITLE
Add *.esh as Erlang syntax highlighting

### DIFF
--- a/ftyperc
+++ b/ftyperc
@@ -958,6 +958,11 @@
 -autoindent
 -tab 4
 
+*.esh
+-syntax erlang
+-autoindent
+-tab 4
+
  Sieve (ManageSieve)
 *.sieve
 -syntax sieve


### PR DESCRIPTION
I've been under the wrong impression that .esh was the "proper" extension for erlang Escript files.
The correct format is ".escript" as described in the reference documentation.
http://erlang.org/doc/man/escript.html

( SORRY )

:)