### PR TITLE
Add Use the correct extension for Erlang escript files

### DIFF
--- a/ftyperc
+++ b/ftyperc
@@ -958,7 +958,7 @@
 -autoindent
 -tab 4
 
-*.esh
+*.escript
 -syntax erlang
 -autoindent
 -tab 4


### PR DESCRIPTION
I've been under the wrong impression that .esh was the "proper" extension for erlang Escript files.
The correct format is ".escript" as described in the reference documentation.
http://erlang.org/doc/man/escript.html

( SORRY )

:)