### PR TITLE
add backtick support for markdown (md.jsf)

### DIFF
--- a/md.jsf
+++ b/md.jsf
@@ -1,4 +1,5 @@
 # JOE syntax highlight file for Markdown
+# by Christian Nicolai (http://mycrobase.de)
 
 # And yes, this *is* a joke :p
 
@@ -33,6 +34,7 @@
 	"\\"		escape		recolor=-1
 	"*_"		maybe_bold1
 	"["		maybe_link_desc1
+	"`"		backtick	buffer noeat
 
 :headline_prefix Idle
 	*		headline
@@ -132,3 +134,20 @@
 
 :link_end Idle
 	*		idle
+
+:backtick Quote
+	*		backtick_body	save_s noeat
+	"`"		backtick
+
+:backtick_body Code
+	*		backtick_body
+	"`"             backtick_end_maybe	buffer
+
+:backtick_end_maybe Code
+	*		backtick_body	strings
+	"&"		backtick_end
+done
+	"`"		backtick_end_maybe
+
+:backtick_end Quote
+	*		idle		noeat


### PR DESCRIPTION
This directly addresses issue #36 . Prior to this md.jsf did nothing for backticks.