### PR TITLE
Python: the highlighter believed that the `@' binary operator is a de…

### DIFF
--- a/python.jsf
+++ b/python.jsf
@@ -27,12 +27,16 @@
 	"\""		string_dq_1	recolor=-1
 	"a-zA-Z_"	ident		noeat
 	"{}"		brace		recolor=-1
-	"@"		decorator	recolor=-1
+	"@"		maybe_decorator
 
 :brace Brace
 	*		idle		noeat
 
 # annotations
+:maybe_decorator Idle
+	"a-zA-Z_"	decorator	recolor=-2
+	" (\t\r\n"	idle		noeat
+
 :decorator Decorator
 	*		decorator
 	" (\t\r\n"	idle		noeat


### PR DESCRIPTION
When I write numpy code such as `a = b @ c`, the `@` is highlighted to be a decorator. Comparing to the statement `a = b * c`, the `*` is not highlighted to be a decorator.
I solved this by adding a `maybe_decorator` state which checks whether the next character is a part of an identifier or not. An identifier means that the `@` is the beginning of a decorator.